### PR TITLE
Add horror-themed hero presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 .env
 .DS_Store
+
+.astro/

--- a/src/components/BloodSplatters.astro
+++ b/src/components/BloodSplatters.astro
@@ -1,0 +1,82 @@
+---
+/* No props; sized to fill parent */
+---
+<svg
+  viewBox="0 0 1600 900"
+  width="100%"
+  height="100%"
+  preserveAspectRatio="xMidYMid slice"
+  class="blood"
+  aria-hidden="true"
+>
+  <defs>
+    <!-- Gooey filter so circles merge -->
+    <filter id="goo">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>
+      <feColorMatrix in="blur" mode="matrix"
+        values="
+          1 0 0 0 0
+          0 1 0 0 0
+          0 0 1 0 0
+          0 0 0 24 -14" result="goo"/>
+      <feBlend in="SourceGraphic" in2="goo"/>
+    </filter>
+
+    <radialGradient id="bloodGrad" cx="50%" cy="40%" r="70%">
+      <stop offset="0%"  stop-color="var(--blood)"/>
+      <stop offset="70%" stop-color="var(--blood)"/>
+      <stop offset="100%" stop-color="var(--blood-2)"/>
+    </radialGradient>
+  </defs>
+
+  <!-- big smear under the word -->
+  <path d="M220,640 C500,610 780,650 1060,620 1150,610 1240,640 1330,670
+           1240,710 1150,730 1060,740 780,770 500,750 220,720 Z"
+        fill="url(#bloodGrad)" opacity="0.95" />
+
+  <!-- blobs -->
+  <g filter="url(#goo)">
+    <circle cx="620" cy="660" r="42" fill="url(#bloodGrad)" />
+    <circle cx="680" cy="660" r="38" fill="url(#bloodGrad)" />
+    <circle cx="725" cy="652" r="26" fill="url(#bloodGrad)" />
+    <circle cx="860" cy="650" r="40" fill="url(#bloodGrad)" />
+    <circle cx="905" cy="655" r="28" fill="url(#bloodGrad)" />
+    <circle cx="960" cy="662" r="34" fill="url(#bloodGrad)" />
+  </g>
+
+  <!-- splat specks -->
+  <g class="specks" fill="var(--blood)">
+    <circle cx="200" cy="710" r="8"/>
+    <circle cx="260" cy="740" r="5"/>
+    <circle cx="310" cy="690" r="6"/>
+    <circle cx="1180" cy="700" r="7"/>
+    <circle cx="1220" cy="740" r="5"/>
+    <circle cx="1280" cy="710" r="6"/>
+    <circle cx="1460" cy="690" r="5"/>
+  </g>
+
+  <!-- scratch streaks -->
+  <g stroke="var(--ink)" stroke-width="3" opacity=".35">
+    <path d="M140 540 Q360 520 560 560" fill="none"/>
+    <path d="M1100 560 Q1300 540 1500 590" fill="none"/>
+    <path d="M200 600 Q460 590 700 620" fill="none"/>
+  </g>
+</svg>
+
+<style>
+  .blood{
+    position:absolute;
+    inset:0;
+    pointer-events:none;
+    mix-blend-mode:normal;
+  }
+  .specks circle{
+    transform-origin:center;
+    animation:breathe 3.5s ease-in-out infinite alternate;
+  }
+  .specks circle:nth-child(odd){ animation-duration:4.2s; }
+  @keyframes breathe{
+    from{ transform:scale(1); opacity:.85; }
+    to  { transform:scale(1.2); opacity:1; }
+  }
+</style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,19 +1,36 @@
 ---
+import Title from './Title.astro';
+import BloodSplatters from './BloodSplatters.astro';
 ---
-<section class="min-h-screen flex items-center justify-center bg-gradient-to-b from-death-black via-gray-900 to-blood-red">
-  <div class="text-center px-4 max-w-4xl">
-    <h1 class="text-6xl md:text-8xl font-bold mb-6 tracking-wider">
-      DEATH<span class="text-blood-red">BOOK</span>
-    </h1>
-    <p class="text-xl md:text-2xl mb-8 italic opacity-90">
-      The Most Dramatic Notebook in Cosplay History (Probably)
-    </p>
-    <p class="text-lg mb-12 max-w-2xl mx-auto">
-      Join our alternative culture community where we take spooky notebooks way too seriously
-      and debate supernatural detective work over coffee.
-    </p>
-    <button class="bg-blood-red hover:bg-red-900 text-white px-8 py-4 text-lg font-bold border-2 border-white transition-all">
-      WRITE YOUR NAME (Just Kidding)
-    </button>
+<section class="hero">
+  <BloodSplatters />
+  <div class="center">
+    <Title />
+    <p class="tag">a moody Astro hero with SVG blood splatter</p>
   </div>
 </section>
+
+<style>
+  .hero{
+    position:relative;
+    min-height:100svh;
+    overflow:hidden;
+  }
+  .center{
+    position:relative;
+    z-index:2;
+    display:grid;
+    place-items:center;
+    min-height:100svh;
+    text-align:center;
+    padding: clamp(1rem, 2vw, 3rem);
+  }
+  .tag{
+    margin-top: .75rem;
+    color:#c8c8c8;
+    letter-spacing:.08em;
+    text-transform:uppercase;
+    font-size: clamp(.7rem, 1.4vw, .9rem);
+    opacity:.7;
+  }
+</style>

--- a/src/components/Title.astro
+++ b/src/components/Title.astro
@@ -1,0 +1,29 @@
+---
+const text = "DEATH NOTE";
+const chars = text.split("");
+---
+<h1 class="title" aria-label={text}>
+  {chars.map((c, i) => <span style={`--i:${i}`}>{c}</span>)}
+</h1>
+
+<style>
+  .title{
+    position:relative;
+    z-index:1;
+    font-family:'Creepster', system-ui, sans-serif;
+    font-size: clamp(3rem, 9vw, 10rem);
+    letter-spacing:.06em;
+    color: var(--text);
+    text-shadow:
+      0 0 1px #fff,
+      0 0 12px rgba(255,255,255,.15);
+    user-select:none;
+  }
+  .title span{
+    display:inline-block;
+    transform:
+      translateY(calc((var(--i) % 2)*-4px))
+      rotate(calc((var(--i) - 5) * 1.5deg));
+    padding-inline: .02em;
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import "../styles/theme.css";
 const { title } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -8,7 +9,7 @@ const { title } = Astro.props;
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{title}</title>
 </head>
-<body class="bg-death-black text-bone-white">
+<body>
   <slot />
 </body>
 </html>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,21 @@
+@import url('https://fonts.googleapis.com/css2?family=Creepster&display=swap');
+
+:root{
+  --bg:#060606;
+  --ink:#0b0b0b;
+  --text:#f5f5f5;
+  --blood:#d10212;
+  --blood-2:#8a0007;
+}
+
+*{ box-sizing:border-box; }
+html,body{ height:100%; }
+body{
+  margin:0;
+  background:
+    radial-gradient(1200px 800px at 60% -20%, #111 0%, transparent 60%) no-repeat,
+    radial-gradient(900px 700px at -20% 20%, #0c0c0c 0%, transparent 55%) no-repeat,
+    var(--bg);
+  color:var(--text);
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+}


### PR DESCRIPTION
## Summary
- add a reusable theme stylesheet with horror-inspired colors and fonts
- create SVG blood splatter and stylized title components for the landing hero
- update layout and hero to use the new styling and include generated Astro env types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07982248083339a85ea6871f499d1