### PR TITLE
Revamp homepage for Yuujou Events

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,10 +1,11 @@
 ---
 ---
-<footer class="bg-death-black border-t-2 border-blood-red py-8 text-center">
-  <p class="text-sm opacity-75">
-    A parody tribute by dramatic cosplay enthusiasts. No actual supernatural powers included.
+<footer class="bg-slate-950/80 backdrop-blur py-10 text-center text-sm text-slate-300">
+  <p class="font-medium text-slate-200">Yuujou Events</p>
+  <p class="mt-2 opacity-80">
+    Bringing together fans for kind-hearted meetups, creative collaborations, and lasting friendships.
   </p>
-  <p class="text-xs mt-2 opacity-50">
-    This is a transformative parody work for a fan community.
+  <p class="mt-4 text-xs opacity-60">
+    Placeholder imagery will be replaced as submissions arrive. Questions? Email hello@yuujou.events
   </p>
 </footer>

--- a/src/components/Rules.astro
+++ b/src/components/Rules.astro
@@ -1,23 +1,46 @@
 ---
+const guidelines = [
+  {
+    title: 'Celebrate friendships',
+    description:
+      'Share stories, photos, and projects that highlight kindness, collaboration, and positive community vibes.'
+  },
+  {
+    title: 'Keep spaces welcoming',
+    description:
+      'Use inclusive language, respect boundaries, and remember that first-time attendees might be nervous.'
+  },
+  {
+    title: 'Ask before you post',
+    description:
+      'Always get permission before uploading images or quoting someone. Placeholder images are here until approvals arrive.'
+  },
+  {
+    title: 'Support creative work',
+    description:
+      'Credit artists and cosplayers, link to portfolios, and uplift one another with constructive feedback.'
+  }
+];
 ---
-<section class="py-20 px-4 bg-death-black">
-  <div class="max-w-4xl mx-auto">
-    <h2 class="text-4xl font-bold mb-12 text-center border-b-2 border-blood-red pb-4">
-      COMMUNITY RULES (Very Official)
-    </h2>
-    <div class="space-y-6 text-lg">
-      <div class="border-l-4 border-blood-red pl-6 py-2">
-        <p>Rule 1: The cosplayer whose photo appears in this gallery becomes infinitely cooler.</p>
-      </div>
-      <div class="border-l-4 border-blood-red pl-6 py-2">
-        <p>Rule 2: Dramatic potato chip eating is encouraged at all meetups.</p>
-      </div>
-      <div class="border-l-4 border-blood-red pl-6 py-2">
-        <p>Rule 3: All moral debates must be accompanied by excessive monologuing.</p>
-      </div>
-      <div class="border-l-4 border-blood-red pl-6 py-2">
-        <p>Rule 4: Tennis matches solve everything. So does cake.</p>
-      </div>
+<section class="relative isolate overflow-hidden rounded-3xl bg-slate-900/70 px-6 py-16 shadow-xl ring-1 ring-white/10">
+  <div class="mx-auto flex max-w-4xl flex-col gap-10 text-left">
+    <div>
+      <h2 class="text-3xl font-semibold text-sky-200 sm:text-4xl">Community Guidelines</h2>
+      <p class="mt-3 text-base text-slate-200/80">
+        Yuujou Events thrives when everyone feels seen and safe. Please review the guidelines below before joining
+        a gathering or posting in the community hub.
+      </p>
     </div>
+    <dl class="space-y-6">
+      {guidelines.map((item) => (
+        <div class="rounded-2xl border border-white/10 bg-slate-900/60 p-6 transition hover:border-sky-300/40">
+          <dt class="text-lg font-semibold text-white">{item.title}</dt>
+          <dd class="mt-2 text-sm text-slate-200/80">{item.description}</dd>
+        </div>
+      ))}
+    </dl>
   </div>
+  <div
+    class="pointer-events-none absolute -right-20 top-1/2 h-72 w-72 -translate-y-1/2 rounded-full bg-sky-500/20 blur-3xl"
+  ></div>
 </section>

--- a/src/components/Title.astro
+++ b/src/components/Title.astro
@@ -1,23 +1,17 @@
 ---
-const letters = [
-  { char: 'D', rotate: '-2deg', x: '0px', y: '0px' },
-  { char: 'E', rotate: '3deg', x: '2px', y: '-2px' },
-  { char: 'A', rotate: '-4deg', x: '-1px', y: '1px' },
-  { char: 'T', rotate: '2deg', x: '1px', y: '-3px' },
-  { char: 'H', rotate: '-3deg', x: '-2px', y: '2px' },
-  { char: 'N', rotate: '4deg', x: '1px', y: '-1px' },
-  { char: 'O', rotate: '-5deg', x: '-2px', y: '0px' },
-  { char: 'T', rotate: '3deg', x: '2px', y: '-2px' },
-  { char: 'E', rotate: '-1deg', x: '0px', y: '1px' }
+const title = [
+  { text: 'Yuujou', accent: true },
+  { text: 'Events', accent: false }
 ];
 ---
-<h1 class="font-[Creepster] text-[clamp(3rem,9vw,8rem)] tracking-[0.25em] uppercase drop-shadow-[0_0_18px_rgba(209,2,18,0.35)]">
-  {letters.map(({ char, rotate, x, y }) => (
+<h1 class="font-bold text-[clamp(2.5rem,6vw,4.5rem)] leading-tight tracking-tight">
+  {title.map(({ text, accent }) => (
     <span
-      class="inline-block origin-center px-[0.06em]"
-      style={`transform: translate(${x}, ${y}) rotate(${rotate});`}
+      class={`block md:inline md:mr-3 ${
+        accent ? 'text-sky-300 drop-shadow-[0_10px_30px_rgba(56,189,248,0.35)]' : 'text-white'
+      }`}
     >
-      {char}
+      {text}
     </span>
   ))}
 </h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,26 +1,127 @@
 ---
 import '../styles/global.css';
-import BloodField from '../components/BloodField.astro';
 import Title from '../components/Title.astro';
+import Rules from '../components/Rules.astro';
+import Footer from '../components/Footer.astro';
 ---
 <head>
-  <title>DEATHNOTE</title>
+  <title>Yuujou Events | Community Gatherings & Guidelines</title>
+  <meta
+    name="description"
+    content="Discover upcoming Yuujou Events, review community guidelines, and explore placeholders for our collaborative gallery."
+  />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Creepster&display=swap"
-    rel="stylesheet"
-  />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
 </head>
 
-<main class="relative h-[100dvh] w-screen overflow-hidden">
-  <BloodField />
-  <section class="relative z-10 grid h-full place-items-center px-6 text-center">
-    <div>
-      <Title />
-      <p class="mt-2 text-xs uppercase tracking-[0.2em] text-neutral-300">
-        floating blood blobs — no big smear
-      </p>
+<main class="relative flex min-h-[100dvh] flex-col overflow-hidden">
+  <section class="relative isolate overflow-hidden px-6 pb-20 pt-28">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute left-1/4 top-10 h-56 w-56 rounded-full bg-sky-500/20 blur-3xl"></div>
+      <div class="absolute right-10 top-32 h-80 w-80 rounded-full bg-emerald-500/10 blur-3xl"></div>
+      <div class="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-black/60 to-transparent"></div>
+    </div>
+    <div class="mx-auto grid max-w-6xl items-center gap-14 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+      <div class="space-y-6">
+        <Title />
+        <p class="max-w-xl text-base text-slate-200/80 sm:text-lg">
+          Welcome to the Yuujou Events hub — your home for uplifting meetups, fandom collaborations, and community
+          spotlights. Browse upcoming gatherings, discover how to participate, and read the guidelines that keep our
+          spaces caring and creative.
+        </p>
+        <div class="flex flex-wrap gap-3 text-sm font-medium text-slate-100">
+          <a
+            href="#guidelines"
+            class="rounded-full bg-sky-500/20 px-5 py-2 transition hover:bg-sky-400/30 hover:text-white"
+          >
+            Read Community Guidelines
+          </a>
+          <a
+            href="#events"
+            class="rounded-full border border-white/20 px-5 py-2 transition hover:border-sky-300/60 hover:text-sky-100"
+          >
+            View Upcoming Highlights
+          </a>
+        </div>
+      </div>
+      <div class="relative rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-2xl">
+        <div class="aspect-[4/3] w-full overflow-hidden rounded-2xl border border-white/10 bg-slate-800/60">
+          <div class="flex h-full w-full flex-col items-center justify-center gap-3 text-center text-slate-200/70">
+            <span class="rounded-full bg-slate-700/60 px-3 py-1 text-xs uppercase tracking-[0.3em]">Preview</span>
+            <p class="max-w-[18ch] text-lg font-medium text-slate-100">Placeholder image — submissions open soon!</p>
+            <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Upload portal launches 08.25</p>
+          </div>
+        </div>
+        <p class="mt-4 text-xs text-slate-300/80">
+          Want to contribute? We will replace this placeholder with community photos once all permissions are cleared.
+        </p>
+      </div>
     </div>
   </section>
+
+  <section id="events" class="relative isolate bg-black/30 px-6 py-20">
+    <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-slate-600/40 to-transparent"></div>
+    <div class="mx-auto flex max-w-6xl flex-col gap-12">
+      <div class="max-w-3xl">
+        <h2 class="text-2xl font-semibold text-white sm:text-3xl">Upcoming Highlights</h2>
+        <p class="mt-3 text-sm text-slate-200/80">
+          Each gathering focuses on collaboration and friendship. Images below are temporary placeholders until our
+          photographers finish curating the new gallery.
+        </p>
+      </div>
+      <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+        {['Friendship Festival', 'Creators Workshop', 'Night Market Meetup'].map((event, index) => (
+          <article class="flex flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70">
+            <div class="relative aspect-[4/3] w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950">
+              <div class="absolute inset-0 grid place-items-center">
+                <div class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-center text-xs uppercase tracking-[0.4em] text-slate-300">
+                  Placeholder {index + 1}
+                </div>
+              </div>
+            </div>
+            <div class="flex flex-1 flex-col gap-3 p-6">
+              <h3 class="text-lg font-semibold text-white">{event}</h3>
+              <p class="text-sm text-slate-200/80">
+                Event details, schedules, and photos are being finalised. Check back soon or join our newsletter for
+                early updates.
+              </p>
+              <div class="mt-auto text-xs font-medium uppercase tracking-[0.3em] text-slate-400">
+                Placeholder imagery — final gallery pending
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section id="guidelines" class="px-6 py-24">
+    <div class="mx-auto max-w-5xl">
+      <Rules />
+    </div>
+  </section>
+
+  <section class="px-6 pb-24">
+    <div class="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-slate-900/70 p-10 text-center shadow-xl">
+      <h2 class="text-2xl font-semibold text-white sm:text-3xl">Need a placeholder asset?</h2>
+      <p class="mt-4 text-sm text-slate-200/80">
+        Download the official Yuujou Events placeholder pack for flyers, slides, and schedule posts. Replace it with
+        your own visuals once you have the all-clear from the participants featured.
+      </p>
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm font-medium text-slate-100">
+        <a
+          href="#"
+          class="rounded-full bg-sky-500/20 px-5 py-2 transition hover:bg-sky-400/30 hover:text-white"
+        >
+          Download Placeholder Pack
+        </a>
+        <a href="mailto:hello@yuujou.events" class="rounded-full border border-white/20 px-5 py-2 transition hover:border-sky-300/60 hover:text-sky-100">
+          Contact the Team
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <Footer />
 </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: dark;
+}
+
 body {
-  @apply m-0 bg-[#060606] text-[#f5f5f5];
+  margin: 0;
+  background: radial-gradient(circle at top, #0d1b3d 0%, #050912 55%, #04050c 100%);
+  color: #f8fbff;
+  font-family: 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100dvh;
+}
+
+a {
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- replace the previous Death Note themed hero with a Yuujou Events introduction and CTA buttons
- add placeholder imagery, upcoming highlights, and a refreshed community guidelines section
- update global styling and footer copy to match the new friendly branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07ff48ec883338dadce9e15d8b259