### PR TITLE
Refine neutral palette and responsive layout

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 ---
-<footer class="bg-slate-950/80 backdrop-blur py-10 text-center text-sm text-slate-300">
-  <p class="font-medium text-slate-200">Yuujou Events</p>
+<footer class="bg-black/80 backdrop-blur py-10 text-center text-sm text-neutral-300">
+  <p class="font-medium text-neutral-200">Yuujou Events</p>
   <p class="mt-2 opacity-80">
     Bringing together fans for kind-hearted meetups, creative collaborations, and lasting friendships.
   </p>

--- a/src/components/Rules.astro
+++ b/src/components/Rules.astro
@@ -22,20 +22,20 @@ const guidelines = [
   }
 ];
 ---
-<section class="relative isolate overflow-hidden rounded-3xl bg-slate-900/70 px-6 py-16 shadow-xl ring-1 ring-white/10">
+<section class="relative isolate overflow-hidden rounded-3xl bg-neutral-950/70 px-6 py-16 shadow-xl ring-1 ring-white/10">
   <div class="mx-auto flex max-w-4xl flex-col gap-10 text-left">
     <div>
-      <h2 class="text-3xl font-semibold text-sky-200 sm:text-4xl">Community Guidelines</h2>
-      <p class="mt-3 text-base text-slate-200/80">
+      <h2 class="text-3xl font-semibold text-red-300 sm:text-4xl">Community Guidelines</h2>
+      <p class="mt-3 text-base text-neutral-200/80">
         Yuujou Events thrives when everyone feels seen and safe. Please review the guidelines below before joining
         a gathering or posting in the community hub.
       </p>
     </div>
     <dl class="space-y-6">
       {guidelines.map((item) => (
-        <div class="rounded-2xl border border-white/10 bg-slate-900/60 p-6 transition hover:border-sky-300/40">
+        <div class="rounded-2xl border border-white/10 bg-neutral-900/60 p-6 transition hover:border-red-400/40">
           <dt class="text-lg font-semibold text-white">{item.title}</dt>
-          <dd class="mt-2 text-sm text-slate-200/80">{item.description}</dd>
+          <dd class="mt-2 text-sm text-neutral-200/80">{item.description}</dd>
         </div>
       ))}
     </dl>

--- a/src/components/Title.astro
+++ b/src/components/Title.astro
@@ -8,7 +8,7 @@ const title = [
   {title.map(({ text, accent }) => (
     <span
       class={`block md:inline md:mr-3 ${
-        accent ? 'text-sky-300 drop-shadow-[0_10px_30px_rgba(56,189,248,0.35)]' : 'text-white'
+        accent ? 'text-red-400 drop-shadow-[0_10px_30px_rgba(248,113,113,0.35)]' : 'text-white'
       }`}
     >
       {text}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,36 +25,36 @@ import Footer from '../components/Footer.astro';
     <div class="mx-auto grid max-w-6xl items-center gap-10 sm:gap-14 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
       <div class="space-y-6">
         <Title />
-        <p class="max-w-xl text-base text-slate-200/80 sm:text-lg">
+        <p class="max-w-xl text-base text-neutral-200/80 sm:text-lg">
           Yuujou Events is a community-driven hub in Aklan dedicated to uniting fans through cosplay, creative
           expression, and shared passions. We host uplifting gatherings, fandom collaborations, and community
           spotlights where friendships can flourish. Discover upcoming meetups, learn how to get involved, and join a
           space that celebrates kindness, artistry, and connection.
         </p>
-        <div class="flex flex-wrap gap-3 text-sm font-medium text-slate-100">
+        <div class="flex flex-wrap gap-3 text-sm font-medium text-neutral-100">
           <a
             href="#guidelines"
-            class="rounded-full bg-sky-500/20 px-5 py-2 transition hover:bg-sky-400/30 hover:text-white"
+            class="w-full rounded-full bg-red-600/20 px-5 py-2 text-center transition hover:bg-red-500/40 hover:text-white sm:w-auto"
           >
             Read Community Guidelines
           </a>
           <a
             href="#events"
-            class="rounded-full border border-white/20 px-5 py-2 transition hover:border-sky-300/60 hover:text-sky-100"
+            class="w-full rounded-full border border-white/20 px-5 py-2 text-center transition hover:border-red-400/60 hover:text-red-200 sm:w-auto"
           >
             View Upcoming Highlights
           </a>
         </div>
       </div>
-      <div class="relative rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-2xl">
-        <div class="aspect-[4/3] w-full overflow-hidden rounded-2xl border border-white/10 bg-slate-800/60">
-          <div class="flex h-full w-full flex-col items-center justify-center gap-3 text-center text-slate-200/70">
-            <span class="rounded-full bg-slate-700/60 px-3 py-1 text-xs uppercase tracking-[0.3em]">Preview</span>
-            <p class="max-w-[18ch] text-lg font-medium text-slate-100">Placeholder image — submissions open soon!</p>
-            <p class="text-xs uppercase tracking-[0.25em] text-slate-400">Upload portal launches 08.25</p>
+      <div class="relative rounded-3xl border border-white/10 bg-neutral-950/70 p-6 shadow-2xl">
+        <div class="aspect-[4/3] w-full overflow-hidden rounded-2xl border border-white/10 bg-neutral-900/60">
+          <div class="flex h-full w-full flex-col items-center justify-center gap-3 text-center text-neutral-200/70">
+            <span class="rounded-full bg-neutral-800/60 px-3 py-1 text-xs uppercase tracking-[0.3em]">Preview</span>
+            <p class="max-w-[18ch] text-lg font-medium text-neutral-100">Placeholder image — submissions open soon!</p>
+            <p class="text-xs uppercase tracking-[0.25em] text-neutral-400">Upload portal launches 08.25</p>
           </div>
         </div>
-        <p class="mt-4 text-xs text-slate-300/80">
+        <p class="mt-4 text-xs text-neutral-300/80">
           Want to contribute? We will replace this placeholder with community photos once all permissions are cleared.
         </p>
       </div>
@@ -62,16 +62,16 @@ import Footer from '../components/Footer.astro';
   </section>
 
   <section id="events" class="relative isolate bg-black/30 px-4 py-16 sm:px-6 sm:py-20">
-    <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-slate-600/40 to-transparent"></div>
+    <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-neutral-600/40 to-transparent"></div>
     <div class="mx-auto flex max-w-6xl flex-col gap-12">
       <div class="max-w-3xl">
         <h2 class="text-2xl font-semibold text-white sm:text-3xl">Upcoming Highlights</h2>
-        <p class="mt-3 text-sm text-slate-200/80">
+        <p class="mt-3 text-sm text-neutral-200/80">
           Each gathering focuses on collaboration and friendship. Images below are temporary placeholders until our
           photographers finish curating the new gallery.
         </p>
       </div>
-      <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+      <div class="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
         {[
           {
             title: 'Friendship Festival',
@@ -92,18 +92,18 @@ import Footer from '../components/Footer.astro';
             footer: 'Nighttime vibes — final shots arriving soon'
           }
         ].map((event, index) => (
-          <article class="flex flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70">
-            <div class="relative aspect-[4/3] w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950">
+          <article class="flex flex-col overflow-hidden rounded-3xl border border-white/10 bg-neutral-950/70">
+            <div class="relative aspect-[4/3] w-full bg-gradient-to-br from-neutral-800 via-neutral-900 to-black">
               <div class="absolute inset-0 grid place-items-center">
-                <div class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-center text-xs uppercase tracking-[0.4em] text-slate-300">
+                <div class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-center text-xs uppercase tracking-[0.4em] text-neutral-300">
                   Placeholder {index + 1}
                 </div>
               </div>
             </div>
             <div class="flex flex-1 flex-col gap-3 p-6">
               <h3 class="text-lg font-semibold text-white">{event.title}</h3>
-              <p class="text-sm text-slate-200/80">{event.description}</p>
-              <div class="mt-auto text-xs font-medium uppercase tracking-[0.3em] text-slate-400">
+              <p class="text-sm text-neutral-200/80">{event.description}</p>
+              <div class="mt-auto text-xs font-medium uppercase tracking-[0.3em] text-neutral-400">
                 {event.footer}
               </div>
             </div>
@@ -120,22 +120,25 @@ import Footer from '../components/Footer.astro';
   </section>
 
   <section class="px-4 pb-20 sm:px-6 sm:pb-24">
-    <div class="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-slate-900/70 p-10 text-center shadow-xl">
+    <div class="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-neutral-950/70 p-10 text-center shadow-xl">
       <h2 class="text-2xl font-semibold text-white sm:text-3xl">Need a placeholder asset?</h2>
-      <p class="mt-4 text-sm text-slate-200/80">
+      <p class="mt-4 text-sm text-neutral-200/80">
         Yuujou Events is built around celebrating the creativity of our community. While we gather final photos and
         artworks, you can download our official placeholder pack for use in flyers, slides, or event posts. Once
         permissions and approvals are cleared, replace them with authentic visuals that highlight the heart of cosplay
         and fan collaboration.
       </p>
-      <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm font-medium text-slate-100">
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm font-medium text-neutral-100">
         <a
           href="#"
-          class="rounded-full bg-sky-500/20 px-5 py-2 transition hover:bg-sky-400/30 hover:text-white"
+          class="w-full rounded-full bg-red-600/20 px-5 py-2 text-center transition hover:bg-red-500/40 hover:text-white sm:w-auto"
         >
           Download Placeholder Pack
         </a>
-        <a href="mailto:hello@yuujou.events" class="rounded-full border border-white/20 px-5 py-2 transition hover:border-sky-300/60 hover:text-sky-100">
+        <a
+          href="mailto:hello@yuujou.events"
+          class="w-full rounded-full border border-white/20 px-5 py-2 text-center transition hover:border-red-400/60 hover:text-red-200 sm:w-auto"
+        >
           Contact the Team
         </a>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top, #0d1b3d 0%, #050912 55%, #04050c 100%);
+  background: radial-gradient(circle at top, #3a3a3a 0%, #161616 50%, #050505 100%);
   color: #f8fbff;
   font-family: 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   min-height: 100dvh;


### PR DESCRIPTION
## Summary
- replace the blue-forward theme with a neutral-to-black palette and red accents across the hero, event cards, and footer
- update guideline callouts and buttons to use the new accent color while keeping contrast accessible
- improve small-screen ergonomics by allowing primary actions to span full width and introducing a tablet-friendly grid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0881c98688333b0e3a825feaaaf6c