### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/Rules.astro
+++ b/src/components/Rules.astro
@@ -24,18 +24,18 @@ const guidelines = [
 ---
 <section class="relative isolate overflow-hidden rounded-3xl bg-neutral-950/70 px-6 py-16 shadow-xl ring-1 ring-white/10">
   <div class="mx-auto flex max-w-4xl flex-col gap-10">
-    <div class="text-center lg:text-left">
+    <div class="text-center sm:text-left">
       <h2 class="text-3xl font-semibold text-red-300 sm:text-4xl">Community Guidelines</h2>
-      <p class="mt-3 text-base text-neutral-200/80 text-balance">
+      <p class="mt-3 text-base leading-relaxed text-neutral-200/80 text-balance">
         Yuujou Events thrives when everyone feels seen and safe. Please review the guidelines below before joining
         a gathering or posting in the community hub.
       </p>
     </div>
     <dl class="space-y-6">
       {guidelines.map((item) => (
-        <div class="rounded-2xl border border-white/10 bg-neutral-900/60 p-6 text-center transition hover:border-red-400/40 lg:text-left">
+        <div class="rounded-2xl border border-white/10 bg-neutral-900/60 p-6 text-left transition hover:border-red-400/40 sm:p-7">
           <dt class="text-lg font-semibold text-white">{item.title}</dt>
-          <dd class="mt-2 text-sm text-neutral-200/80 text-balance">{item.description}</dd>
+          <dd class="mt-2 text-sm leading-relaxed text-neutral-200/80 text-balance">{item.description}</dd>
         </div>
       ))}
     </dl>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,8 @@ import Rules from '../components/Rules.astro';
 import Footer from '../components/Footer.astro';
 ---
 <head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Yuujou Events | Community Gatherings & Guidelines</title>
   <meta
     name="description"
@@ -16,47 +18,49 @@ import Footer from '../components/Footer.astro';
 </head>
 
 <main class="relative flex min-h-[100dvh] flex-col overflow-hidden">
-  <section class="relative isolate overflow-hidden px-4 pb-16 pt-24 sm:px-6 sm:pb-20 sm:pt-28">
+  <section class="relative isolate overflow-hidden px-4 pb-14 pt-20 sm:px-6 sm:pb-20 sm:pt-28">
     <div class="absolute inset-0 -z-10">
       <div class="absolute left-1/4 top-10 h-56 w-56 rounded-full bg-red-500/20 blur-3xl"></div>
       <div class="absolute right-10 top-32 h-80 w-80 rounded-full bg-rose-900/20 blur-3xl"></div>
       <div class="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-black/60 to-transparent"></div>
     </div>
-    <div class="mx-auto grid max-w-6xl items-center gap-10 sm:gap-14 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+    <div class="mx-auto grid max-w-6xl items-start gap-12 sm:gap-14 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
       <div class="space-y-6 text-center lg:text-left">
         <Title />
-        <p class="mx-auto max-w-xl text-base text-neutral-200/80 text-balance lg:mx-0 lg:text-lg">
+        <p class="mx-auto max-w-2xl text-base leading-relaxed text-neutral-200/80 text-balance lg:mx-0 lg:text-lg">
           Yuujou Events is a community-driven hub in Aklan dedicated to uniting fans through cosplay, creative
           expression, and shared passions. We host uplifting gatherings, fandom collaborations, and community
           spotlights where friendships can flourish. Discover upcoming meetups, learn how to get involved, and join a
           space that celebrates kindness, artistry, and connection.
         </p>
-        <div class="flex flex-wrap justify-center gap-3 text-sm font-medium text-neutral-100 lg:justify-start">
+        <div class="mx-auto flex w-full max-w-sm flex-wrap justify-center gap-3 text-sm font-medium text-neutral-100 lg:mx-0 lg:justify-start">
           <a
             href="#guidelines"
-            class="w-full rounded-full bg-red-600/20 px-5 py-2 text-center transition hover:bg-red-500/40 hover:text-white lg:w-auto"
+            class="w-full rounded-full bg-red-600/20 px-5 py-2.5 text-center transition hover:bg-red-500/40 hover:text-white lg:w-auto"
           >
             Read Community Guidelines
           </a>
           <a
             href="#events"
-            class="w-full rounded-full border border-white/20 px-5 py-2 text-center transition hover:border-red-400/60 hover:text-red-200 lg:w-auto"
+            class="w-full rounded-full border border-white/20 px-5 py-2.5 text-center transition hover:border-red-400/60 hover:text-red-200 lg:w-auto"
           >
             View Upcoming Highlights
           </a>
         </div>
       </div>
-      <div class="relative mt-10 rounded-3xl border border-white/10 bg-neutral-950/70 p-6 shadow-2xl lg:mt-0">
+      <div class="relative mt-12 rounded-3xl border border-white/10 bg-neutral-950/70 p-6 shadow-2xl sm:p-7 lg:mt-0">
         <div class="aspect-[4/3] w-full overflow-hidden rounded-2xl border border-white/10 bg-neutral-900/60">
-          <div class="flex h-full w-full flex-col items-center justify-center gap-3 px-4 text-center text-neutral-200/70">
-            <span class="rounded-full bg-neutral-800/60 px-3 py-1 text-xs uppercase tracking-[0.3em]">Preview</span>
-            <p class="max-w-[22ch] text-base font-medium text-neutral-100 text-balance sm:text-lg">
+          <div class="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center text-neutral-200/70">
+            <span class="rounded-full bg-neutral-800/60 px-3 py-1 text-xs uppercase tracking-[0.25em] sm:tracking-[0.3em]">Preview</span>
+            <p class="max-w-[24ch] text-sm font-medium text-neutral-100 text-balance sm:text-base">
               Placeholder image — submissions open soon!
             </p>
-            <p class="text-xs uppercase tracking-[0.2em] text-neutral-400 sm:tracking-[0.25em]">Upload portal launches 08.25</p>
+            <p class="text-xs uppercase tracking-[0.15em] text-neutral-400 sm:tracking-[0.25em]">
+              Upload portal launches 08.25
+            </p>
           </div>
         </div>
-        <p class="mt-4 text-xs text-neutral-300/80 text-balance">
+        <p class="mt-4 text-xs leading-relaxed text-neutral-300/80 text-balance">
           Want to contribute? We will replace this placeholder with community photos once all permissions are cleared.
         </p>
       </div>
@@ -66,14 +70,16 @@ import Footer from '../components/Footer.astro';
   <section id="events" class="relative isolate bg-black/30 px-4 py-16 scroll-mt-24 sm:px-6 sm:py-20">
     <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-neutral-600/40 to-transparent"></div>
     <div class="mx-auto flex max-w-6xl flex-col gap-12">
-      <div class="max-w-3xl text-center lg:text-left">
+      <div class="max-w-3xl text-center md:text-left">
         <h2 class="text-2xl font-semibold text-white sm:text-3xl">Upcoming Highlights</h2>
-        <p class="mt-3 text-sm text-neutral-200/80 text-balance">
+        <p class="mt-3 text-sm leading-relaxed text-neutral-200/80 text-balance">
           Each gathering focuses on collaboration and friendship. Images below are temporary placeholders until our
           photographers finish curating the new gallery.
         </p>
       </div>
-      <div class="grid gap-8 sm:grid-cols-2 xl:grid-cols-3">
+      <div
+        class="flex snap-x snap-mandatory gap-6 overflow-x-auto pb-6 [-mx-4] px-4 sm:[-mx-6] sm:px-6 md:grid md:mx-0 md:snap-none md:gap-8 md:overflow-visible md:px-0 md:pb-0 sm:grid-cols-2 xl:grid-cols-3"
+      >
         {[
           {
             title: 'Friendship Festival',
@@ -94,18 +100,22 @@ import Footer from '../components/Footer.astro';
             footer: 'Nighttime vibes — final shots arriving soon'
           }
         ].map((event, index) => (
-          <article class="flex flex-col overflow-hidden rounded-3xl border border-white/10 bg-neutral-950/70 text-center lg:text-left">
+          <article
+            class="flex min-w-[85%] snap-start flex-col overflow-hidden rounded-3xl border border-white/10 bg-neutral-950/70 text-left shadow-lg transition hover:border-red-400/40 sm:min-w-[65%] md:min-w-0 md:text-left"
+          >
             <div class="relative aspect-[4/3] w-full bg-gradient-to-br from-neutral-800 via-neutral-900 to-black">
               <div class="absolute inset-0 grid place-items-center">
-                <div class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-center text-xs uppercase tracking-[0.3em] text-neutral-300 sm:tracking-[0.4em]">
+                <div
+                  class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-center text-xs uppercase tracking-[0.2em] text-neutral-300 sm:tracking-[0.35em]"
+                >
                   Placeholder {index + 1}
                 </div>
               </div>
             </div>
             <div class="flex flex-1 flex-col gap-3 p-6">
               <h3 class="text-lg font-semibold text-white">{event.title}</h3>
-              <p class="text-sm text-neutral-200/80 text-balance">{event.description}</p>
-              <div class="mt-auto text-xs font-medium uppercase tracking-[0.2em] text-neutral-400 sm:tracking-[0.3em]">
+              <p class="text-sm leading-relaxed text-neutral-200/80 text-balance">{event.description}</p>
+              <div class="mt-auto text-xs font-medium uppercase tracking-[0.12em] text-neutral-400 sm:tracking-[0.28em]">
                 {event.footer}
               </div>
             </div>
@@ -122,9 +132,9 @@ import Footer from '../components/Footer.astro';
   </section>
 
   <section class="px-4 pb-20 sm:px-6 sm:pb-24">
-    <div class="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-neutral-950/70 p-10 text-center shadow-xl">
+    <div class="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-neutral-950/70 p-8 text-center shadow-xl sm:p-10">
       <h2 class="text-2xl font-semibold text-white sm:text-3xl">Need a placeholder asset?</h2>
-      <p class="mt-4 text-sm text-neutral-200/80 text-balance">
+      <p class="mt-4 text-sm leading-relaxed text-neutral-200/80 text-balance">
         Yuujou Events is built around celebrating the creativity of our community. While we gather final photos and
         artworks, you can download our official placeholder pack for use in flyers, slides, or event posts. Once
         permissions and approvals are cleared, replace them with authentic visuals that highlight the heart of cosplay
@@ -133,13 +143,13 @@ import Footer from '../components/Footer.astro';
       <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm font-medium text-neutral-100">
         <a
           href="#"
-          class="w-full rounded-full bg-red-600/20 px-5 py-2 text-center transition hover:bg-red-500/40 hover:text-white sm:w-auto"
+          class="w-full rounded-full bg-red-600/20 px-5 py-2.5 text-center transition hover:bg-red-500/40 hover:text-white sm:w-auto"
         >
           Download Placeholder Pack
         </a>
         <a
           href="mailto:hello@yuujou.events"
-          class="w-full rounded-full border border-white/20 px-5 py-2 text-center transition hover:border-red-400/60 hover:text-red-200 sm:w-auto"
+          class="w-full rounded-full border border-white/20 px-5 py-2.5 text-center transition hover:border-red-400/60 hover:text-red-200 sm:w-auto"
         >
           Contact the Team
         </a>


### PR DESCRIPTION
## Summary
- add missing meta tags and tighten hero spacing for better mobile scaling
- adapt highlight cards into a horizontal snap list on small screens while keeping the desktop grid
- tweak guideline cards and call-to-action spacing for improved readability on phones

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0bba4e1188333bb05fde0d86b4044